### PR TITLE
Prevent potential infinite loop in BPR

### DIFF
--- a/librec/src/main/java/librec/ranking/BPR.java
+++ b/librec/src/main/java/librec/ranking/BPR.java
@@ -62,7 +62,7 @@ public class BPR extends IterativeRecommender {
 					u = Randoms.uniform(numUsers);
 					SparseVector pu = userCache.get(u);
 
-					if (pu.getCount() == 0)
+					if (pu.getCount() == 0 || pu.getCount() == numItems)
 						continue;
 
 					int[] is = pu.getIndex();


### PR DESCRIPTION
If a user has rated all items, the loop to select document J may become an infinite loop.