### PR TITLE
BPR configuration parameters printout in log message

### DIFF
--- a/librec/src/main/java/librec/ranking/BPR.java
+++ b/librec/src/main/java/librec/ranking/BPR.java
@@ -106,6 +106,6 @@ public class BPR extends IterativeRecommender {
 
 	@Override
 	public String toString() {
-		return Strings.toString(new Object[] { numFactors, initLRate, maxLRate, regB, regU, regI, numIters, isBoldDriver }, ",");
+		return Strings.toString(new Object[] { numFactors, initLRate, maxLRate, 0.0, regU, regI, numIters, isBoldDriver }, ",");
 	}
 }

--- a/librec/src/main/java/librec/ranking/BPR.java
+++ b/librec/src/main/java/librec/ranking/BPR.java
@@ -31,6 +31,7 @@ import librec.util.Strings;
  * @author guoguibing
  * 
  */
+@Configuration("factors, lRate, maxLRate, regU, regI, numIters, isBoldDriver")
 public class BPR extends IterativeRecommender {
 
 	public BPR(SparseMatrix trainMatrix, SparseMatrix testMatrix, int fold) {
@@ -106,6 +107,6 @@ public class BPR extends IterativeRecommender {
 
 	@Override
 	public String toString() {
-		return Strings.toString(new Object[] { numFactors, initLRate, maxLRate, 0.0, regU, regI, numIters, isBoldDriver }, ",");
+		return Strings.toString(new Object[] { numFactors, initLRate, maxLRate, regU, regI, numIters, isBoldDriver }, ",");
 	}
 }

--- a/librec/src/main/java/librec/ranking/BPR.java
+++ b/librec/src/main/java/librec/ranking/BPR.java
@@ -106,6 +106,6 @@ public class BPR extends IterativeRecommender {
 
 	@Override
 	public String toString() {
-		return Strings.toString(new Object[] { binThold, numFactors, initLRate, maxLRate, regU, regI, numIters }, ",");
+		return Strings.toString(new Object[] { numFactors, initLRate, maxLRate, regB, regU, regI, numIters, isBoldDriver }, ",");
 	}
 }

--- a/librec/src/main/java/librec/ranking/BPR.java
+++ b/librec/src/main/java/librec/ranking/BPR.java
@@ -31,7 +31,7 @@ import librec.util.Strings;
  * @author guoguibing
  * 
  */
-@Configuration("factors, lRate, maxLRate, regU, regI, numIters, isBoldDriver")
+@Configuration("binThold, factors, lRate, maxLRate, regU, regI, numIters, isBoldDriver")
 public class BPR extends IterativeRecommender {
 
 	public BPR(SparseMatrix trainMatrix, SparseMatrix testMatrix, int fold) {
@@ -107,6 +107,6 @@ public class BPR extends IterativeRecommender {
 
 	@Override
 	public String toString() {
-		return Strings.toString(new Object[] { numFactors, initLRate, maxLRate, regU, regI, numIters, isBoldDriver }, ",");
+		return Strings.toString(new Object[] { binThold, numFactors, initLRate, maxLRate, regU, regI, numIters, isBoldDriver }, ",");
 	}
 }


### PR DESCRIPTION
- binthold does not affect BPRs configuration
- this also fixes the discrepancy between the names of variables, and their values
