### PR TITLE
Fixed bug with getName method of MetricRec10 (returned wrong name)

### DIFF
--- a/librec/src/main/java/librec/metric/IRankingMetric.java
+++ b/librec/src/main/java/librec/metric/IRankingMetric.java
@@ -108,7 +108,7 @@ class MetricRec5 implements IRankingMetric<Integer> {
 class MetricRec10 implements IRankingMetric<Integer> {
     private double m_sumRec;
     private double m_rec;
-    public String getName () { return "Rec5";}
+    public String getName () { return "Rec10";}
 
     public void init(Recommender rec) {
         m_sumRec = 0.0;


### PR DESCRIPTION
MetricRec10 had a copy and paste bug (returns Rec5 as name instead of Rec10). 