### PR TITLE
2.0.0 alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We hope you will enjoy the new version!
 
 ### Download
 * **librec-v2.0** is coming soon!
-   * Alpha version: check out the new branch (2.0.0-alpha) 
+   * Alpha version: check out the new git branch (2.0.0-alpha) 
       * Note that this update is not a stable release, and bugs and issues may exist here and there for now. This version is suitable for those who seek for the latest update and changes in LibRec 2.0. The stable version will be available by the end of December 2016. 
    * Beta version by the middle of December 2016
    * Full version by the end of December 2016

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We hope you will enjoy the new version!
 
 ### Download
 * **librec-v2.0** is coming soon!
-   * Alpha version: check out the new git branch (2.0.0-alpha)
+   * Alpha version: check out the new branch (2.0.0-alpha) 
       * Note that this update is not a stable release, and bugs and issues may exist here and there for now. This version is suitable for those who seek for the latest update and changes in LibRec 2.0. The stable version will be available by the end of December 2016. 
    * Beta version by the middle of December 2016
    * Full version by the end of December 2016
@@ -67,7 +67,6 @@ public void main(String[] args) throws Exception {
 	List<RecommendedItem> recommendedItemList = recommender.getRecommendedList();
 	RecommendedFilter filter = new GenericRecommendedFilter();
 	recommendedItemList = filter.filter(recommendedItemList);
-
 }
 </pre>
 

--- a/core/src/main/java/net/librec/recommender/AbstractRecommender.java
+++ b/core/src/main/java/net/librec/recommender/AbstractRecommender.java
@@ -134,7 +134,7 @@ public abstract class AbstractRecommender implements Recommender {
      */
     protected void setup() throws LibrecException {
         conf = context.getConf();
-        isRanking = conf.getBoolean("rec.recommender.category");
+        isRanking = conf.getBoolean("rec.recommender.isranking");
         if (isRanking) {
             topN = conf.getInt("rec.recommender.ranking.topn", 5);
         }


### PR DESCRIPTION
This is a small change. I am proposing to replace the configuration parameter "rec.recommender.category" with "rec.recommender.isranking". "category" implies that the content of this properties will be a category name, so it is confusing for it to be a boolean value. "isranking" clarifies that a boolean value is wanted and that the value reflects when the recommender is used for ranking or not. 
