### PR TITLE
2.0.0 alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We hope you will enjoy the new version!
 
 ### Download
 * **librec-v2.0** is coming soon!
-   * Alpha version: check out the new branch (2.0.0-alpha) 
+   * Alpha version: check out the new git branch (2.0.0-alpha) 
       * Note that this update is not a stable release, and bugs and issues may exist here and there for now. This version is suitable for those who seek for the latest update and changes in LibRec 2.0. The stable version will be available by the end of December 2016. 
    * Beta version by the middle of December 2016
    * Full version by the end of December 2016


### PR DESCRIPTION
This is a bug fix for RecommendedItemList.

The problem I was having may be hard to reproduce -- it showed up when using a version of the Yelp Challenge dataset. I can share the data with you if you're interested.

A NoSuchElement exception was thrown inside UserItemRatingItr.next() at the point when the recommendation results were being saved. I think what was happening was the hasNext() was reporting that there were more elements in this collection even when there weren't any. The call to RecommendedItemList.this.getItemIdxListByUserIdx(userIdx).iterator() was returning an empty iterator and the following itemEntryItr.next() call was throwing the exception.

My proposed fix is to check itemEntryItr.hasNext() before this call and return null if there are no elements. The calling function handles a null return value correctly, so this fix seems to be the right one. I could not find anywhere else in the code where UserItemRatingItr is used. 

There is perhaps a larger issue in that UserItemRatingItr.hasNext() should return false in this case and it doesn't. I was not sufficiently confident in my understanding of the various indices inside RecommendedItemList to attempt a fix at that level. 