### PR TITLE
Set splitter name as in driver.classes.props

### DIFF
--- a/core/src/main/java/net/librec/job/RecommenderJob.java
+++ b/core/src/main/java/net/librec/job/RecommenderJob.java
@@ -113,7 +113,7 @@ public class RecommenderJob {
             case "testset":{
             	executeRecommenderJob();
             }
-            case "given": {
+            case "givenn": {
                 executeRecommenderJob();
                 break;
             }


### PR DESCRIPTION
Fixed a bug that does not allow the execution of a job using the GivenN splitter.