### PR TITLE
bugfix for TextDataConvertor

### DIFF
--- a/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
+++ b/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
@@ -276,6 +276,8 @@ public class TextDataConvertor extends AbstractDataConvertor {
                 }
                 if (!isComplete) {
                     bufferLine = bufferData[bufferData.length - 1];
+                }else{
+                    bufferLine = "";
                 }
                 buffer.clear();
             }


### PR DESCRIPTION
bufferLine is a String variable for saving String in every loop. However, if bufferLine was completed in last loop, then the concat function will add the old string processed and the new string which is not together. It will lead to duplication of processing the same string twice or even more.