### PR TITLE
Bug + fix: the value of matric is wrong when using a ranking evaluator alone

### DIFF
--- a/core/src/main/java/net/librec/recommender/AbstractRecommender.java
+++ b/core/src/main/java/net/librec/recommender/AbstractRecommender.java
@@ -337,7 +337,10 @@ public abstract class AbstractRecommender implements Recommender {
      * @throws LibrecException if error occurs during evaluating
      */
     public double evaluate(RecommenderEvaluator evaluator) throws LibrecException {
-        return evaluator.evaluate(context, recommendedList);
+        if ( isRanking && topN>0)
+        	evaluator.setTopN(topN);	// if isRanking is true and topN>0, set the top-N of evaluator
+        
+    	return evaluator.evaluate(context, recommendedList);
     }
 
     /**


### PR DESCRIPTION
## the value of matric is wrong when useing a ranking evaluator alone

whenever you test any recommendation strategy ,if you try to get the value of ranking evaluator alone, the result is wrong.For example, you test UserKNN and  get the precision , like the  following :
'''
RecommenderEvaluator precision = new PrecisionEvaluator();
 System.out.println("pr: " +recommender.evaluate(precision));
'''
**the  result  is  NaN**,.
By debugging , I find when the funtion *evaluate * of AbstractRecommenderEvaluator calculate the result ,the topN of PrecisionEvaluator  is  zero. So my solution  is to set the topN at a suitable time.
Sorry I'm a  fresherman on Github ,I hope  you have understood what I meant.