### PR TITLE
fix TextDataConvertor: clear bufferLine when the last line is complete.

### DIFF
--- a/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
+++ b/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
@@ -280,6 +280,8 @@ public class TextDataConvertor extends AbstractDataConvertor {
                 }
                 if (!isComplete) {
                     bufferLine = bufferData[bufferData.length - 1];
+                } else {
+                    bufferLine = "";
                 }
                 buffer.clear();
             }


### PR DESCRIPTION
The bug is found by 贺黎 from LibRec WeChat community.