### PR TITLE
解决工程编译问题

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,6 +19,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>1.2</version>

--- a/core/src/main/java/net/librec/recommender/content/ConvMFDocumentProvider.java
+++ b/core/src/main/java/net/librec/recommender/content/ConvMFDocumentProvider.java
@@ -17,7 +17,7 @@
  */
 package net.librec.recommender.content;
 
-import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.datavec.api.util.RandomUtils;
 import org.nd4j.linalg.primitives.Pair;
 
@@ -40,7 +40,7 @@ public class ConvMFDocumentProvider {
     private int labelSize;
     private int numDoc;
 
-    public ConvMFDocumentProvider(@NonNull List<String> documents, @NonNull List<double[]> labelsForSentences) {
+    public ConvMFDocumentProvider(@NotNull List<String> documents, @NotNull List<double[]> labelsForSentences) {
         this(documents, labelsForSentences, new Random());
         if(documents == null) {
             throw new NullPointerException("document");
@@ -49,7 +49,7 @@ public class ConvMFDocumentProvider {
         }
     }
 
-    public ConvMFDocumentProvider(@NonNull List<String> documents, @NonNull List<double[]> labelsForDocuments, Random rng) {
+    public ConvMFDocumentProvider(@NotNull List<String> documents, @NotNull List<double[]> labelsForDocuments, Random rng) {
         this.cursor = 0;
         if(documents == null) {
             throw new NullPointerException("documents");

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,15 @@
 		<log4j.version>1.2.17</log4j.version>
 		<nd4j.version>0.9.1</nd4j.version>
 		<dl4j.version>0.9.1</dl4j.version>
+		<lombok.version>1.18.2</lombok.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.projectlombok</groupId>
+				<artifactId>lombok</artifactId>
+				<version>${lombok.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>commons-cli</groupId>
 				<artifactId>commons-cli</artifactId>
@@ -82,6 +88,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
 					<configuration>
 						<source>${java.version}</source>
 						<target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,14 @@
 		<log4j.version>1.2.17</log4j.version>
 		<nd4j.version>0.9.1</nd4j.version>
 		<dl4j.version>0.9.1</dl4j.version>
-		<lombok.version>1.18.2</lombok.version>
+		<jetbrains-annotations.version>16.0.2</jetbrains-annotations.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.projectlombok</groupId>
-				<artifactId>lombok</artifactId>
-				<version>${lombok.version}</version>
+				<groupId>org.jetbrains</groupId>
+				<artifactId>annotations</artifactId>
+				<version>${jetbrains-annotations.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-cli</groupId>
@@ -82,6 +82,12 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+		</dependency>
+	</dependencies>
 	<build>
 		<pluginManagement>
 			<plugins>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -72,38 +72,10 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.scala-tools</groupId>
-				<artifactId>maven-scala-plugin</artifactId>
-				<version>2.15.2</version>
-				<executions>
-					<execution>
-						<id>scala-compile-first</id>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-						<configuration>
-							<includes>
-								<include>**/*.scala</include>
-							</includes>
-						</configuration>
-					</execution>
-					<execution>
-						<id>scala-test-compile</id>
-						<goals>
-							<goal>testCompile</goal>
-						</goals>
-					</execution>
-				</executions>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.4.2</version>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
- 修正了代码中引用但未在 pom 文件中声明的类库
- 补充了 maven 编译插件的最新版本号.
- 更新官方 Scala maven 插件. 使 `mvn complie` 可以正确编译整个工程