### PR TITLE
update data.input.path and data.appender.path in sbpr-test.properties file

### DIFF
--- a/core/src/main/resources/rec/context/ranking/sbpr-test.properties
+++ b/core/src/main/resources/rec/context/ranking/sbpr-test.properties
@@ -1,5 +1,6 @@
 data.appender.class=social
-data.appender.path=test/test-append-dir
+data.appender.path=epinions/trust
+data.input.path=epinions/rating
 
 rec.recommender.class=sbpr
 rec.iterator.learnrate=0.01


### PR DESCRIPTION
The default dataset to run here is filmtrust, but SBPR paper didn't have this dataset, it have epinions dataset, so may be change "data.input.path" into "epinions/rating" and change "data.appender.path" into "epinions/trust" will be more friendly for others who want to reproduce this paper.
