### PR TITLE
Fix bug and Implement JDBC read data module, including JDBCDataModel JDBCDataConvertor, etc

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,9 @@
 
 	<properties>
 		<jar.commons-logging.version>1.2</jar.commons-logging.version>
+		<mysql-jdbc.version>5.1.47</mysql-jdbc.version>
+		<hadoop.version>3.3.0</hadoop.version>
+		<hive-jdbc.version>3.1.2</hive-jdbc.version>
 	</properties>
 
 	<dependencies>
@@ -76,5 +79,25 @@
 			<artifactId>nd4j-native-platform</artifactId>
 			<version>${nd4j.version}</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>${mysql-jdbc.version}</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.hive/hive-jdbc -->
+		<dependency>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-jdbc</artifactId>
+			<version>${hive-jdbc.version}</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common -->
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<version>${hadoop.version}</version>
+		</dependency>
+
+
 	</dependencies>
 </project>

--- a/core/src/main/java/net/librec/data/DataConvertor.java
+++ b/core/src/main/java/net/librec/data/DataConvertor.java
@@ -23,6 +23,7 @@ import net.librec.math.structure.SequentialAccessSparseMatrix;
 import net.librec.math.structure.SparseTensor;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 /**
  * A <tt>DataConvertor</tt> is an interface to convert
@@ -37,7 +38,7 @@ public interface DataConvertor {
      *
      * @throws IOException if the path is not valid
      */
-    void processData() throws IOException;
+    void processData() throws IOException, SQLException;
 
     /**
      * Returns a {@code SparseMatrix} object which stores rate data.

--- a/core/src/main/java/net/librec/data/convertor/AbstractDataConvertor.java
+++ b/core/src/main/java/net/librec/data/convertor/AbstractDataConvertor.java
@@ -27,6 +27,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 /**
  * A <tt>AbstractDataConvertor</tt> is a class to convert
@@ -67,7 +68,7 @@ public abstract class AbstractDataConvertor extends ProgressReporter implements 
         if (null == matrix){
             try {
                 processData();
-            } catch (IOException e) {
+            } catch (IOException | SQLException e) {
                 e.printStackTrace();
             }
         }

--- a/core/src/main/java/net/librec/data/convertor/JDBCDataConvertor.java
+++ b/core/src/main/java/net/librec/data/convertor/JDBCDataConvertor.java
@@ -17,9 +17,201 @@
  */
 package net.librec.data.convertor;
 
-/**
- * JDBC Data Convertor
- */
-public class JDBCDataConvertor {
+import com.google.common.collect.BiMap;
+import net.librec.math.structure.DataFrame;
+import net.librec.util.StringUtil;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
+import java.io.IOException;
+import java.sql.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A <tt>JDBCDataConvertor</tt>is a class to convert
+ * a data file from Database format to a target format.
+ *
+ * @author jiajingzhe
+ */
+public class JDBCDataConvertor extends AbstractDataConvertor {
+
+    /**
+     * Log
+     */
+    private static final Log LOG = LogFactory.getLog(JDBCDataConvertor.class);
+
+    /**
+     * The attributes of JDBCDataConvertor
+     */
+    private String driverName = ""; // The default is mysql
+    private String URL = "";
+    private String user = "";
+    private String password = "";
+    private String tableName = "";
+    private String userColName = "";
+    private String itemColName = "";
+    private String ratingColName = "";
+    private String datetimeColName = "";
+
+    private Connection conn = null;
+    private ResultSet result = null;
+    private PreparedStatement pst = null;
+    private String[] header;
+    private String[] attr;
+    private float fileRate;
+    /**
+     * the threshold to binarize a rating. If a rating is greater than the threshold, the value will be 1;
+     * otherwise 0. To disable this appender, i.e., keep the original rating value, set the threshold a negative value
+     */
+    private double binThold = -1.0;
+
+    /**
+     * user/item {raw id, inner id} map
+     */
+    private BiMap<String, Integer> userIds, itemIds;
+
+    /**
+     * time unit may depend on data sets, e.g. in MovieLens, it is unix seconds
+     */
+    private TimeUnit timeUnit = TimeUnit.SECONDS;
+
+
+    public JDBCDataConvertor(String driverName, String URL, String user, String password, String tableName, String userColName, String itemColName, String ratingColName, String datetimeColName) {
+        this.driverName = driverName;
+        this.URL = URL;
+        this.user = user;
+        this.password = password;
+        this.tableName = tableName;
+        this.userColName = userColName;
+        this.itemColName = itemColName;
+        this.ratingColName = ratingColName;
+        this.datetimeColName = datetimeColName;
+
+        if (this.isNotBlank()) {
+            try {
+                Class.forName(this.driverName);
+                this.conn = DriverManager.getConnection(this.URL, this.user, this.password);
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+            }
+        }
+        else{
+            LOG.error("Incomplete database connection configuration information!");
+        }
+    }
+
+    /**
+     * Check whether each required parameter is null, empty .
+     * And fields other than datetimeColName cannot be spaces
+     */
+    public boolean isNotBlank() {
+        return StringUtils.isNotBlank(this.driverName) &&
+                StringUtils.isNotBlank(this.URL) &&
+                StringUtils.isNotBlank(this.user) &&
+                StringUtils.isNotBlank(this.password) &&
+                StringUtils.isNotBlank(this.tableName) &&
+                StringUtils.isNotBlank(this.userColName) &&
+                StringUtils.isNotBlank(this.itemColName) &&
+                StringUtils.isNotBlank(this.ratingColName) &&
+                StringUtils.isNotEmpty(this.datetimeColName);
+    }
+
+    @Override
+    public void processData() throws IOException, SQLException {
+        selectData();
+    }
+
+    private void selectData() throws SQLException {
+        LOG.info(String.format("Dataset: %s", this.URL + "/" + this.tableName));
+        matrix = new DataFrame();
+        if (Objects.isNull(header)) {
+            if (StringUtils.isNotBlank(this.datetimeColName)) {
+                header = new String[]{"user", "item", "rating", "datetime"};
+                attr = new String[]{"STRING", "STRING", "NUMERIC", "DATE"};
+            } else {
+                header = new String[]{"user", "item", "rating"};
+                attr = new String[]{"STRING", "STRING", "NUMERIC"};
+            }
+        }
+        matrix.setAttrType(attr);
+        matrix.setHeader(header);
+
+        // Get the number of entries of all data
+        int numEntries = -1;
+        try {
+            String SQL = String.format("SELECT count(1) AS numEntries FROM %s", this.tableName);
+            pst = this.conn.prepareStatement(SQL);
+            ResultSet rs = pst.executeQuery();
+            if (rs.next()){
+                numEntries = rs.getInt("numEntries");
+
+            }
+
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        }
+
+        // Get Data
+        int cur = 0;
+        try {
+            String SQL = "";
+            if (StringUtils.isNotBlank(this.datetimeColName)) {
+                SQL = String.format("SELECT %s,%s,%s,%s FROM %s", this.userColName, this.itemColName, this.ratingColName, this.datetimeColName, this.tableName);
+            } else {
+                SQL = String.format("SELECT %s,%s,%s FROM %s", this.userColName, this.itemColName, this.ratingColName, this.tableName);
+            }
+            PreparedStatement pst = this.conn.prepareStatement(SQL);
+
+            result = pst.executeQuery();
+            String[] paras = new String[header.length];
+            while (result.next()) {
+                paras[0] = result.getString(this.userColName);
+                paras[1] = result.getString(this.itemColName);
+                paras[2] = result.getString(this.ratingColName);
+                if (header.length > 3) {
+                    paras[3] = result.getString(this.datetimeColName);
+                }
+                for (int i = 0; i < header.length; i++) {
+                    if (Objects.equals(attr[i], "STRING")) {
+                        DataFrame.setId(paras[i], matrix.getHeader(i));
+                    }
+                }
+                matrix.add(paras);
+
+                cur++;
+                fileRate = cur / numEntries;
+            }
+            LOG.info(String.format("DataSet: %s is finished", this.tableName));
+
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        } finally {
+            // 关闭连接，释放资源
+            if (this.result != null) {
+                this.result.close();
+            }
+            if (this.pst != null) {
+                this.pst.close();
+            }
+            if (this.conn != null) {
+                this.conn.close();
+            }
+        }
+        List<Double> ratingScale = matrix.getRatingScale();
+        if (ratingScale != null) {
+            LOG.info(String.format("rating Scale: %s", ratingScale.toString()));
+        }
+        LOG.info(String.format("user number: %d,\t item number is: %d", matrix.numUsers(), matrix.numItems()));
+    }
+
+    @Override
+    public void progress() {
+        getJobStatus().setProgress(fileRate);
+    }
 }

--- a/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
+++ b/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
@@ -98,7 +98,7 @@ public class TextDataConvertor extends AbstractDataConvertor {
     }
 
     public TextDataConvertor(String dataColumnFormat, String inputDataPath) {
-        this(dataColumnFormat, inputDataPath, " ");
+        this(dataColumnFormat, inputDataPath, ",");
     }
 
     public TextDataConvertor(String[] header, String[] attr, String inputDataPath, String sep) {

--- a/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
+++ b/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java
@@ -89,7 +89,7 @@ public class TextDataConvertor extends AbstractDataConvertor {
 
     /**
      * Initializes a newly created {@code TextDataConvertor} object with the
-     * path of the input data file.
+     * path of the input data file.The delimiter of this file defaults to ","
      *
      * @param inputDataPath the path of the input data file
      */

--- a/core/src/main/java/net/librec/data/model/JDBCDataModel.java
+++ b/core/src/main/java/net/librec/data/model/JDBCDataModel.java
@@ -19,35 +19,85 @@ package net.librec.data.model;
 
 import com.google.common.collect.BiMap;
 import net.librec.common.LibrecException;
+import net.librec.conf.Configuration;
+import net.librec.data.convertor.JDBCDataConvertor;
 import net.librec.math.structure.DataSet;
 
+import java.io.IOException;
+import java.sql.SQLException;
+
 /**
- * JDBC Data Model
+ * A <tt>JDBCDataModel</tt> represents a data access class to the database format
+ * input.
+ *
+ * @author Jiajingzhe
  */
 public class JDBCDataModel extends AbstractDataModel {
 
+    /**
+     * Empty constructor.
+     */
+    public JDBCDataModel() {
+    }
+    /**
+     * Initializes a newly created {@code JDBCDataModel} object with
+     * configuration.
+     *
+     * @param conf the configuration for the model.
+     */
+    public JDBCDataModel(Configuration conf) {
+        this.conf = conf;
+    }
+
+    /**
+     * Build Convert.
+     *
+     * @throws LibrecException if error occurs during building
+     */
     @Override
     protected void buildConvert() throws LibrecException {
-        // TODO Auto-generated method stub
+        String driverName = conf.get("data.convert.jbdc.driverName","com.mysql.jdbc.Driver"); // The default is mysql
+        String URL = conf.get("data.convert.jbdc.URL");
+        String user = conf.get("data.convert.jbdc.user");
+        String password = conf.get("data.convert.jbdc.password");
+        String tableName = conf.get("data.convert.jbdc.tableName");
+        String userColName = conf.get("data.convert.jbdc.userColName");
+        String itemColName = conf.get("data.convert.jbdc.itemColName");
+        String ratingColName =conf.get("data.convert.jbdc.ratingColName");
+        String datetimeColName = conf.get("data.convert.jbdc.datetimeColName"," ");
+
+        dataConvertor = new JDBCDataConvertor(driverName,URL,user,password,tableName,userColName,itemColName,ratingColName,datetimeColName);
+        try{
+            dataConvertor.processData();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        }
 
     }
 
+    /**
+     * Load data model.
+     *
+     * @throws LibrecException if error occurs during loading
+     */
     @Override
-    public BiMap<String, Integer> getUserMappingData() {
-        // TODO Auto-generated method stub
-        return null;
+    public void loadDataModel() throws LibrecException {
+
     }
 
+    /**
+     * Save data model.
+     *
+     * @throws LibrecException if error occurs during saving
+     */
     @Override
-    public BiMap<String, Integer> getItemMappingData() {
-        // TODO Auto-generated method stub
-        return null;
-    }
+    public void saveDataModel() throws LibrecException {
 
+    }
     @Override
     public DataSet getDatetimeDataSet() {
-        // TODO Auto-generated method stub
-        return null;
+        return dataConvertor.getDatetimeMatrix();
     }
-
 }

--- a/core/src/main/java/net/librec/data/model/TextDataModel.java
+++ b/core/src/main/java/net/librec/data/model/TextDataModel.java
@@ -24,6 +24,7 @@ import net.librec.data.convertor.TextDataConvertor;
 import net.librec.math.structure.DataSet;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 /**
  * A <tt>TextDataModel</tt> represents a data access class to the CSV format
@@ -67,6 +68,8 @@ public class TextDataModel extends AbstractDataModel {
             dataConvertor.processData();
         } catch (IOException e) {
             e.printStackTrace();
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
         }
     }
 

--- a/core/src/main/java/net/librec/data/splitter/GivenTestSetDataSplitter.java
+++ b/core/src/main/java/net/librec/data/splitter/GivenTestSetDataSplitter.java
@@ -27,6 +27,7 @@ import net.librec.math.structure.MatrixEntry;
 import net.librec.math.structure.SequentialAccessSparseMatrix;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 /**
  * Given Test Set Data Splitter<br>
@@ -87,6 +88,8 @@ public class GivenTestSetDataSplitter extends AbstractDataSplitter {
             testConvertor.processData();
         }catch (IOException e) {
             e.printStackTrace();
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
         }
 
         testMatrix = testConvertor.getPreferenceMatrix(conf);

--- a/core/src/test/java/net/librec/data/model/JDBCDataModelTestCase.java
+++ b/core/src/test/java/net/librec/data/model/JDBCDataModelTestCase.java
@@ -1,0 +1,201 @@
+package net.librec.data.model;
+
+import net.librec.BaseTestCase;
+import net.librec.common.LibrecException;
+import net.librec.conf.Configured;
+import net.librec.data.DataModel;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * JDBCDataModel TestCase {@link net.librec.data.model.JDBCDataModel}
+ *
+ * @author jiajingzhe
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class JDBCDataModelTestCase extends BaseTestCase {
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        conf.set("data.convert.jbdc.driverName","com.mysql.jdbc.Driver");
+        conf.set("data.convert.jbdc.URL","jdbc:mysql://<ip>:<port>/librec_test?useSSL=false");
+        conf.set("data.convert.jbdc.user","root");
+        conf.set("data.convert.jbdc.password","password");
+        conf.set("data.convert.jbdc.tableName","test");
+        conf.set("data.convert.jbdc.userColName","usercol");
+        conf.set("data.convert.jbdc.itemColName","itemcol");
+        conf.set("data.convert.jbdc.ratingColName","ratingcol");
+
+        conf.set("data.model.splitter", "ratio");
+        conf.set("data.splitter.trainset.ratio", "0.8");
+        conf.set("data.splitter.ratio", "rating");
+
+    }
+    /**
+     * test the function of convertor part
+     * {@link net.librec.data.convertor.JDBCDataConvertor} input data subject to
+     * format UIR: userId itemId rating
+     *
+     * @throws LibrecException
+     */
+    @Test
+    public void test01ColumnFormatUIR() throws LibrecException {
+        conf.set("data.column.format","UIR");
+        JDBCDataModel dataModel = new JDBCDataModel(conf);
+        dataModel.buildDataModel();
+        assertEquals(getDataSize(dataModel), 5);
+    }
+    @Test
+    public void test02ColumnFormatUIRT() throws LibrecException {
+        conf.set("data.column.format","UIRT");
+        conf.set("data.convert.jbdc.datetimeColName","datacol");
+        JDBCDataModel dataModel = new JDBCDataModel(conf);
+        dataModel.buildDataModel();
+        assertEquals(getDataSize(dataModel), 5);
+    }
+    @Test
+    public void test03HiveUIRT() throws LibrecException {
+        conf.set("data.convert.jbdc.driverName","org.apache.hive.jdbc.HiveDriver");
+        conf.set("data.convert.jbdc.URL","jdbc:hive2://<ip>:<port>/default");
+        conf.set("data.convert.jbdc.user","root");
+        conf.set("data.convert.jbdc.password","password");
+        conf.set("data.convert.jbdc.tableName","librec_jdbc_test");
+        conf.set("data.convert.jbdc.userColName","usercol");
+        conf.set("data.convert.jbdc.itemColName","itemcol");
+        conf.set("data.convert.jbdc.ratingColName","ratingcol");
+        conf.set("data.column.format","UIRT");
+        conf.set("data.convert.jbdc.datetimeColName","datacol");
+        JDBCDataModel dataModel = new JDBCDataModel(conf);
+        dataModel.buildDataModel();
+        assertEquals(getDataSize(dataModel), 5);
+    }
+    /**
+     * Test the function of splitter part.
+     * {@link net.librec.data.splitter.RatioDataSplitter} Sort all ratings by
+     * date,and split the data by rating ratio.
+     *
+     * @throws LibrecException
+     */
+    @Test
+    public void test04RatingDateRatio() throws LibrecException {
+        conf.set("data.model.splitter", "ratio");
+        conf.set("data.splitter.trainset.ratio", "0.8");
+        conf.set("data.splitter.ratio", "ratingdate");
+        conf.set(Configured.CONF_DATA_COLUMN_FORMAT, "UIRT");
+        conf.set("data.convert.jbdc.datetimeColName","datacol");
+
+        JDBCDataModel dataModel = new JDBCDataModel(conf);
+        dataModel.buildDataModel();
+
+        double actualRatio = getTrainRatio(dataModel);
+        assertTrue(Math.abs(actualRatio - 0.8) <= 0.01);
+    }
+
+    /**
+     * Test the function of splitter part.
+     * {@link net.librec.data.splitter.RatioDataSplitter} Sort each user's
+     * ratings by date, and split by user ratio.
+     *
+     * @throws LibrecException
+     */
+    @Test
+    public void test05UserDateRatio() throws LibrecException {
+        conf.set("data.model.splitter", "ratio");
+        conf.set("data.splitter.trainset.ratio", "0.8");
+        conf.set("data.splitter.ratio", "userdate");
+        conf.set(Configured.CONF_DATA_COLUMN_FORMAT, "UIRT");
+        conf.set("data.convert.jbdc.datetimeColName","datacol");
+
+        TextDataModel dataModel = new TextDataModel(conf);
+        dataModel.buildDataModel();
+
+        double actualRatio = getTrainRatio(dataModel);
+        assertTrue(Math.abs(actualRatio - 0.8) <= 0.02);
+    }
+
+    /**
+     * Returns the size of preference matrix of a specified DataModel object
+     *
+     * @param dataModel
+     *            a DataModel object
+     * @return the size of preference matrix of a specified DataModel object
+     */
+    public int getDataSize(DataModel dataModel) {
+        int sum = 0;
+        int train = getTrainSize(dataModel);
+        int test = getTestSize(dataModel);
+        if (null != dataModel.getDataSplitter().getValidData()) {
+            int valid = getValidSize(dataModel);
+            sum += valid;
+        }
+        sum = sum + train + test;
+        return sum;
+    }
+
+    /**
+     * Returns the size of training matrix of a specified DataModel object
+     *
+     * @param dataModel
+     *            a DataModel object
+     * @return the size of training matrix of a specified DataModel object
+     */
+    public int getTrainSize(DataModel dataModel) {
+        return dataModel.getDataSplitter().getTrainData().size();
+    }
+
+    /**
+     * Returns the size of test matrix of a specified DataModel object
+     *
+     * @param dataModel
+     *            a DataModel object
+     * @return the size of test matrix of a specified DataModel object
+     */
+    public int getTestSize(DataModel dataModel) {
+        return dataModel.getDataSplitter().getTestData().size();
+    }
+
+    /**
+     * Returns the size of validation matrix of a specified DataModel object
+     *
+     * @param dataModel
+     *            a DataModel object
+     * @return the size of validation matrix of a specified DataModel object
+     */
+    public int getValidSize(DataModel dataModel) {
+        return dataModel.getDataSplitter().getValidData().size();
+    }
+
+    /**
+     * calculate the ratio of training set of a specified DataModel object
+     *
+     * @param dataModel
+     *            a DataModel object
+     * @return the ratio of training set of a specified DataModel object
+     */
+    public double getTrainRatio(DataModel dataModel) {
+        double trainSize = getTrainSize(dataModel);
+        double totalSize = getDataSize(dataModel);
+
+        return trainSize / totalSize;
+    }
+
+    /**
+     * calculate the ratio of validation set of a specified DataModel object
+     *
+     * @param dataModel
+     *            a DataModel object
+     * @return the ratio of validation set of a specified DataModel object
+     */
+    public double getValidRatio(DataModel dataModel) {
+        double validSize = getValidSize(dataModel);
+        double totalSize = getDataSize(dataModel);
+
+        return validSize / totalSize;
+    }
+}


### PR DESCRIPTION
The main work:
1. Fix the punctuation problem in librec/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java, the default delimiter for csv format files is comma. But it is written as a space in a certain constructor
[https://github.com/guoguibing/librec/blob/84fc31b4abd5597112cf904235df5d7816438c64/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java#L100-L102](https://github.com/guoguibing/librec/blob/84fc31b4abd5597112cf904235df5d7816438c64/core/src/main/java/net/librec/data/convertor/TextDataConvertor.java#L100-L102)

2. Implemented JDBCDataModel and JDBCDataConvertor.
And realized a simple test. The database password was processed. The following is a table statement.
```
CREATE EXTERNAL TABLE `librec_jdbc_test`  (
  `usercol`string ,
  `itemcol` string ,
  `ratingcol` int,
  `datacol` string 
) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',';

INSERT INTO `librec_jdbc_test`(`usercol`, `itemcol`, `ratingcol`, `datacol`) VALUES ('1', '1', 1, '1');
INSERT INTO `librec_jdbc_test`(`usercol`, `itemcol`, `ratingcol`, `datacol`) VALUES ('adas', 'cv', 2, '2');
INSERT INTO `librec_jdbc_test`(`usercol`, `itemcol`, `ratingcol`, `datacol`) VALUES ('asda', '1', 3, '3');
INSERT INTO `librec_jdbc_test`(`usercol`, `itemcol`, `ratingcol`, `datacol`) VALUES ('2', '2', 4, '4');
INSERT INTO `librec_jdbc_test`(`usercol`, `itemcol`, `ratingcol`, `datacol`) VALUES ('3', '3', 3, '5');
```